### PR TITLE
Add MIT License file to the project

### DIFF
--- a/Licence.md
+++ b/Licence.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Shivam Kumar 
+Copyright (c) 2025 Webinex
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Licence.md
+++ b/Licence.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shivam Kumar 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell     
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:                       
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.                               
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR    
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,      
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE   
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER        
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.


### PR DESCRIPTION
This update adds the MIT License to the repository, clearly defining how the project can be used, shared, and modified.

The MIT License is a permissive open-source license that allows: Use for personal, educational, or commercial purposes. Copying, modification, merging, publishing, distribution, sublicensing, and/or selling copies of the software.